### PR TITLE
fixed distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ struct distance_calculator
     __device__
     float operator()(const float4 pos, const object& f) const noexcept
     {
-        // calculate distance...
+        // calculate square distance...
     }
 };
 

--- a/main.cu
+++ b/main.cu
@@ -19,9 +19,9 @@ struct distance_calculator
     __device__
     float operator()(const float4 point, const float4 object) const noexcept
     {
-        return ::sqrtf((point.x - object.x) * (point.x - object.x) +
-                       (point.y - object.y) * (point.y - object.y) +
-                       (point.z - object.z) * (point.z - object.z));
+        return (point.x - object.x) * (point.x - object.x) +
+               (point.y - object.y) * (point.y - object.y) +
+               (point.z - object.z) * (point.z - object.z);
     }
 };
 


### PR DESCRIPTION
Due to the fact that mindist and minmaxdist are used squared here: https://github.com/ToruNiina/lbvh/blob/master/lbvh/aabb.cuh#L63 the user must compute distance also squared.
Here the example is fixed to make it more clear to the user